### PR TITLE
Support split premiere non-elimination episodes and Season 12 challenges

### DIFF
--- a/components/EpisodeList.tsx
+++ b/components/EpisodeList.tsx
@@ -61,6 +61,13 @@ const EpisodeList = ({
         });
 
         const isFinale = ep.type?.toLowerCase().includes("finale");
+        const episodeTypeKeys = ep.type
+          ?.toLowerCase()
+          .split(",")
+          .map((key: string) => key.trim()) || [];
+        const isSplitPremiereNonElim = episodeTypeKeys.some(
+          (key: string) => key.replace(/\s+/g, "") === "nonelim"
+        );
 
         return (
           <div
@@ -111,30 +118,42 @@ const EpisodeList = ({
                   >
                     High
                   </button>
+                  {isSplitPremiereNonElim && (
+                    <button
+                      className="px-3 py-1 text-xs rounded-full bg-indigo-200 hover:bg-indigo-300 transition"
+                      onClick={(e) => handleEventClick(e, ep.episodeNumber, "top2", ep.nonElimination || "")}
+                    >
+                      Top 2
+                    </button>
+                  )}
                   <button
                     className="px-3 py-1 text-xs rounded-full bg-blue-200 hover:bg-blue-400 transition"
                     onClick={(e) => handleEventClick(e, ep.episodeNumber, "winner", ep.nonElimination || "")}
                   >
                     Winner
                   </button>
-                  <button
-                    className="px-3 py-1 text-xs rounded-full bg-red-200 hover:bg-red-300 transition"
-                    onClick={(e) => handleEventClick(e, ep.episodeNumber, "bottom", ep.nonElimination || "")}
-                  >
-                    Bottom
-                  </button>
-                  <button
-                    className="px-3 py-1 text-xs rounded-full bg-red-300 hover:bg-red-400 transition"
-                    onClick={(e) => handleEventClick(e, ep.episodeNumber, "bottom2", ep.nonElimination || "")}
-                  >
-                    Bottom 2
-                  </button>
-                  <button
-                    className="px-3 py-1 text-xs rounded-full bg-red-600 hover:bg-red-800 transition text-white"
-                    onClick={(e) => handleEventClick(e, ep.episodeNumber, "eliminated", ep.nonElimination || "")}
-                  >
-                    Elimination
-                  </button>
+                  {!isSplitPremiereNonElim && (
+                    <>
+                      <button
+                        className="px-3 py-1 text-xs rounded-full bg-red-200 hover:bg-red-300 transition"
+                        onClick={(e) => handleEventClick(e, ep.episodeNumber, "bottom", ep.nonElimination || "")}
+                      >
+                        Bottom
+                      </button>
+                      <button
+                        className="px-3 py-1 text-xs rounded-full bg-red-300 hover:bg-red-400 transition"
+                        onClick={(e) => handleEventClick(e, ep.episodeNumber, "bottom2", ep.nonElimination || "")}
+                      >
+                        Bottom 2
+                      </button>
+                      <button
+                        className="px-3 py-1 text-xs rounded-full bg-red-600 hover:bg-red-800 transition text-white"
+                        onClick={(e) => handleEventClick(e, ep.episodeNumber, "eliminated", ep.nonElimination || "")}
+                      >
+                        Elimination
+                      </button>
+                    </>
+                  )}
                 </>
               )}
             </div>

--- a/components/EpisodeMessage.tsx
+++ b/components/EpisodeMessage.tsx
@@ -4,6 +4,7 @@ const EVENT_LBLS: Record<string, string> = {
     announceSafe: "Safe Queens",
     winner: "Winner",
     high: "High Queens",
+    top2: "Top 2 Queens",
     bottom: "Bottom Queens",
     bottom2: "Bottom 2",
     eliminated: "Eliminated Queen",
@@ -17,7 +18,7 @@ const EpisodeMessage = ({ episodeEvent, eventMessage } : { episodeEvent: string,
     let lipsyncMessage = "";
     let afterStr = '';
     
-    if (episodeEvent === "bottom2" && eventMessage.includes("lipsync to")) {
+    if ((episodeEvent === "bottom2" || episodeEvent === "top2") && eventMessage.includes("lipsync to")) {
         const [before, after] = eventMessage.split("They will now have to lipsync to");
         mainMessage = before.trim();
         lipsyncMessage = "They will now have to lipsync to" + after;

--- a/components/SeasonTrackRecordChart.tsx
+++ b/components/SeasonTrackRecordChart.tsx
@@ -28,6 +28,7 @@ const placementValueToLabel: Record<number, string> = {
     7: "WINNER",
     6: "RUNNER-UP",
     5: "WIN",
+    4.5: "TOP2",
     4: "HIGH",
     3: "SAFE",
     2: "LOW",
@@ -60,6 +61,7 @@ const SeasonTrackRecordChart = ({ queens, episodes }: SeasonTrackRecordChartProp
             case "WINNER": return 7;
             case "RUNNER-UP": return 6;
             case "win": return 5;
+            case "top2": return 4.5;
             case "high": return 4;
             case "safe": return 3;
             case "low": return 2;
@@ -76,6 +78,7 @@ const SeasonTrackRecordChart = ({ queens, episodes }: SeasonTrackRecordChartProp
             case 7: return "WINNER";
             case 6: return "RUNNER-UP";
             case 5: return "WIN";
+            case 4.5: return "TOP2";
             case 4: return "HIGH";
             case 3: return "SAFE";
             case 2: return "LOW";
@@ -151,7 +154,7 @@ const SeasonTrackRecordChart = ({ queens, episodes }: SeasonTrackRecordChartProp
                     <YAxis
                         type="number"
                         domain={[0, 7]}
-                        ticks={[0, 1, 2, 3, 4, 5, 6, 7]}
+                        ticks={[0, 1, 2, 3, 4, 4.5, 5, 6, 7]}
                         tickFormatter={valueToLabel}
                     />
                     <Tooltip />

--- a/components/SeasonTrackRecordTable.tsx
+++ b/components/SeasonTrackRecordTable.tsx
@@ -101,6 +101,8 @@ const SeasonTrackRecordTable = ({
         return "WIN";
       case "high":
         return "HIGH";
+      case "top2":
+        return "TOP2";
       case "safe":
         return "SAFE";
       case "low":
@@ -246,6 +248,7 @@ const SeasonTrackRecordTable = ({
                           ${isAfterElim ? "text-gray-400 bg-gray-200 italic" : ""}
                           ${placement == ' ' ? "text-gray-400 bg-gray-200 italic" : ""}
                           ${placement === "HIGH" ? "bg-sky-300 text-black-200" : ""}
+                          ${placement === "TOP2" ? "bg-indigo-200 text-black" : ""}
                           ${placement === "WIN" ? "bg-blue-400 text-black-200" : ""}
                           ${placement === "LOW" ? "bg-pink-200 text-black-200" : ""}
                           ${placement === "BTM2" ? "bg-red-300 text-black-200" : ""}

--- a/components/SimLayout.tsx
+++ b/components/SimLayout.tsx
@@ -170,6 +170,8 @@ const SimLayout = (
             return placement?.placement === 'safe';
           case 'winner':
             return placement?.placement === 'win';
+          case 'top2':
+            return placement?.placement === 'top2';
           case 'high':
             return placement?.placement === 'high';
           case 'bottom':
@@ -238,6 +240,18 @@ const SimLayout = (
           : `${others.join(', ')}, and ${last} are declared winners!`;
       case 'high':
         return names.length === 1 ? `${names[0]} has placed high.` : `${others.join(', ')}, and ${last} have placed high.`;
+      case 'top2': {
+        const groupedNames = names.length === 1
+          ? names[0]
+          : `${others.join(', ')}${others.length ? ` and ${last}` : last}`;
+        const intro = names.length === 1
+          ? `${groupedNames} is in the Top Two and will lipsync for the win.`
+          : `${groupedNames} are the Top Two and will lipsync for the win.`;
+        if (lipsyncTitle && lipsyncArtist) {
+          return `${intro} They will now have to lipsync to ${lipsyncTitle} by ${lipsyncArtist}. Good luck and don't fuck it up!`;
+        }
+        return intro;
+      }
       case 'bottom':
         return names.length === 1 ? `${names[0]} has placed low.` : `${others.join(', ')}, and ${last} have placed low.`;
       case 'bottom2':

--- a/constants/queenData.ts
+++ b/constants/queenData.ts
@@ -2504,6 +2504,132 @@ export const queens = [
 
 export const episodes = [
   {
+    id: 'us12ep01',
+    title: "I'm That Bitch",
+    episodeNumber: 1,
+    type: 'premiere,musical,nonelim',
+    description: "Seven new queens write original verses and perform RuPaul's new track 'I'm That Bitch' in front of Nicki Minaj.",
+    season: '12',
+    franchise: 'US'
+  },
+  {
+    id: 'us12ep02',
+    title: "You Don't Know Me",
+    episodeNumber: 2,
+    type: 'premiere,musical,nonelim',
+    description: "The remaining seven queens compose and perform verses to 'You Don't Know Me' as Robin Thicke guest judges.",
+    season: '12',
+    franchise: 'US'
+  },
+  {
+    id: 'us12ep03',
+    title: "World's Worst",
+    episodeNumber: 3,
+    type: 'improv,comedy',
+    description: 'The queens star in an improv comedy competition inspired by the worst talent show acts imaginable.',
+    season: '12',
+    franchise: 'US'
+  },
+  {
+    id: 'us12ep04',
+    title: 'The Ball Ball',
+    episodeNumber: 4,
+    type: 'ball,design',
+    description: 'A design-filled triple ball challenge tests the queens on sports, basketball wives, and balls to the wall eleganza.',
+    season: '12',
+    franchise: 'US'
+  },
+  {
+    id: 'us12ep05',
+    title: "Gay's Anatomy",
+    episodeNumber: 5,
+    type: 'acting,comedy',
+    description: 'The queens perform in a parody medical drama that devolves into romantic chaos inside the Werk Room hospital.',
+    season: '12',
+    franchise: 'US'
+  },
+  {
+    id: 'us12ep06',
+    title: 'Snatch Game',
+    episodeNumber: 6,
+    type: 'snatchGame,comedy,improv',
+    description: 'Pop culture impressions take center stage as the queens deliver their best celebrity impersonations in Snatch Game.',
+    season: '12',
+    franchise: 'US'
+  },
+  {
+    id: 'us12ep07',
+    title: 'Madonna: The Unauthorized Rusical',
+    episodeNumber: 7,
+    type: 'musical,dancing,singing',
+    description: 'A full-on Rusical tribute to Madonna challenges the queens to sing, dance, and embody the Queen of Pop.',
+    season: '12',
+    franchise: 'US'
+  },
+  {
+    id: 'us12ep08',
+    title: 'Droop',
+    episodeNumber: 8,
+    type: 'branding,commercial',
+    description: 'RuPaul tasks the queens with creating a commercial for the newest drag essential: the Droop lifestyle brand.',
+    season: '12',
+    franchise: 'US'
+  },
+  {
+    id: 'us12ep09',
+    title: 'Choices 2020',
+    episodeNumber: 9,
+    type: 'improv,comedy',
+    description: 'The queens hit the debate stage to deliver platform comedy in a political town hall moderated by Jeff Goldblum and Rachel Bloom.',
+    season: '12',
+    franchise: 'US'
+  },
+  {
+    id: 'us12ep10',
+    title: 'Superfan Makeover',
+    episodeNumber: 10,
+    type: 'makeover',
+    description: 'Dedicated Drag Race superfans receive sickening makeovers and join their queen idols for a twin runway.',
+    season: '12',
+    franchise: 'US'
+  },
+  {
+    id: 'us12ep11',
+    title: 'One-Queen Show',
+    episodeNumber: 11,
+    type: 'comedy,improv',
+    description: 'Each queen produces a solo showstopper performance showcasing their charisma, uniqueness, nerve, and talent.',
+    season: '12',
+    franchise: 'US'
+  },
+  {
+    id: 'us12ep12',
+    title: 'Viva Drag Vegas',
+    episodeNumber: 12,
+    type: 'acting,dance',
+    description: 'A show-stopping performance number inspired by RuPaul\'s Drag Race Live in Las Vegas closes out the competition stage.',
+    season: '12',
+    franchise: 'US'
+  },
+  {
+    id: 'us12ep13',
+    title: 'Reunited',
+    episodeNumber: 13,
+    type: 'reunion',
+    description: 'The season 12 queens reconnect virtually to spill the tea and reflect on the season with RuPaul.',
+    season: '12',
+    franchise: 'US'
+  },
+  {
+    id: 'us12ep14',
+    title: 'Grand Finale',
+    episodeNumber: 14,
+    type: 'finale',
+    description: "RuPaul crowns America's Next Drag Superstar after a remote finale and lip-sync showdown from home.",
+    season: '12',
+    franchise: 'US'
+  },
+  {
     id: 'EtQVuMqKSIH4wMfZ8BF2',
     title: 'Drag Con Panel Extravaganza',
     episodeNumber: 6,
@@ -4833,6 +4959,11 @@ export const seasons = [
   {
     id: 'txf82x1awXgwEZBcNCVl',
     seasonNumber: '11',
+    franchise: 'US',
+  },
+  {
+    id: 'txf82x1awXgwEZBcNCVm',
+    seasonNumber: '12',
     franchise: 'US',
   },
 ];


### PR DESCRIPTION
## Summary
- add logic for split premiere non-elimination episodes with top two lip sync results
- expose Top 2 controls and messaging in the simulator interface for applicable episodes
- update track record visuals to recognize the new TOP2 placement
- add Season 12 episode data with split premiere non-elimination tags and enable full-season imports

## Testing
- npm run lint (warnings only)

------
https://chatgpt.com/codex/tasks/task_e_68e335f073e8833284ffdf09f93d094d